### PR TITLE
In `replace_number()`, coerce input text to character vector, to prevent surprises with numeric vector inputs

### DIFF
--- a/R/replace_number.R
+++ b/R/replace_number.R
@@ -35,6 +35,8 @@
 #' }
 replace_number  <-
 function(text.var, num.paste = TRUE, remove = FALSE) {
+    
+    text.var <- as.character(text.var)
 
     if (remove) return(gsub("[0-9]", "", text.var))
 


### PR DESCRIPTION
This should be harmless for the large majority of the time when someone inputs a character vector, but should prevent issues that arise when the input is a numeric vector.

As an illustration of the issues with a numeric vector input, 
compare `replace_number(999999)` and `replace_number("999999")`, which both return what you'd expect, to `replace_number(1000000)` and `replace_number("1000000")`, which give different results.