### PR TITLE
Changed multigsub to use mgsub::mgsub

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Depends: R (>= 3.1.0), qdapDictionaries (>= 1.0.2), qdapRegex (>= 0.1.2), qdapTo
 Imports: chron, dplyr (>= 0.3), gdata, gender (>= 0.5.1), ggplot2 (>= 2.1.0), grid, gridExtra,
           igraph, methods, NLP, openNLP (>= 0.2-1), parallel, plotrix, RCurl, reports,
           reshape2, scales, stringdist, tidyr, tm (>= 0.7.2), tools, venneuler, wordcloud,
-          xlsx, XML
+          xlsx, XML, mgsub
 Suggests: koRpus, knitr, lda, proxy, stringi, SnowballC, testthat
 LazyData: TRUE
 VignetteBuilder: knitr

--- a/R/multigsub.R
+++ b/R/multigsub.R
@@ -11,14 +11,8 @@
 #' replacements.
 #' @param trailspace logical.  If \code{TRUE} inserts a trailing space in the 
 #' replacements.
-#' @param fixed logical. If \code{TRUE}, pattern is a string to be matched as is. 
-#' Overrides all conflicting arguments.
 #' @param trim logical.  If \code{TRUE} leading and trailing white spaces are 
 #' removed and multiple white spaces are reduced to a single white space.
-#' @param order.pattern logical.  If \code{TRUE} and \code{fixed = TRUE}, the 
-#' \code{pattern} string is sorted by number of characters to prevent substrings 
-#' replacing meta strings (e.g., \code{pattern = c("the", "then")} resorts to 
-#' search for "then" first).
 #' @param \dots Additional arguments passed to \code{\link[base]{gsub}}.
 #' @rdname multigsub
 #' @return \code{multigsub} - Returns a vector with the pattern replaced.
@@ -53,21 +47,14 @@
 #' }
 multigsub <-
 function (pattern, replacement, text.var, leadspace = FALSE, 
-    trailspace = FALSE, fixed = TRUE, trim = TRUE, order.pattern = fixed, 
-    ...) {
+    trailspace = FALSE, trim = TRUE, ...) {
 
     if (leadspace | trailspace) replacement <- spaste(replacement, trailing = trailspace, leading = leadspace)
-
-    if (fixed && order.pattern) {
-        ord <- rev(order(nchar(pattern)))
-        pattern <- pattern[ord]
-        if (length(replacement) != 1) replacement <- replacement[ord]
-    }
+    
     if (length(replacement) == 1) replacement <- rep(replacement, length(pattern))
-   
-    for (i in seq_along(pattern)){
-        text.var <- gsub(pattern[i], replacement[i], text.var, fixed = fixed, ...)
-    }
+    
+    names(replacement) = pattern
+    text.var = mgsub::mgsub(text.var,replacement)
 
     if (trim) text.var <- gsub("\\s+", " ", gsub("^\\s+|\\s+$", "", text.var, perl=TRUE), perl=TRUE)
     text.var


### PR DESCRIPTION
I noticed at work that the `mgsub` implementation in `qdap` doesn't do it's operations in a way that support transposition, word shifting or protection against regex substring matching.  I've captured and documented examples on my blog. http://thug-r.life/post/2018-01-26-mgsub-launched/

I forked qdap, added mgsub as a dependency and modifed the multigsub function to use mgsub::mgsub.  I tested the functionality of the new mgsub and it works in all cases now.