### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ qdap
 ====
 
 [![Project Status: Inactive – The project has reached a stable, usable state but is no longer being actively developed; support/maintenance will be provided as time allows.](http://www.repostatus.org/badges/latest/inactive.svg)](http://www.repostatus.org/#inactive)
-[![Build Status](https://travis-ci.org/trinker/qdap.svg?branch=master)](https://travis-ci.org/trinker/qdap) [![DOI](https://zenodo.org/badge/5398/trinker/qdap.svg)](http://dx.doi.org/10.5281/zenodo.11124)
+[![Build Status](https://travis-ci.org/trinker/qdap.svg?branch=master)](https://travis-ci.org/trinker/qdap) [![DOI](https://zenodo.org/badge/5398/trinker/qdap.svg)](https://doi.org/10.5281/zenodo.11124)
 [![](http://cranlogs.r-pkg.org/badges/qdap)](https://cran.r-project.org/package=qdap)
 
 

--- a/inst/Rmd_vignette/qdap_vignette.Rmd
+++ b/inst/Rmd_vignette/qdap_vignette.Rmd
@@ -6853,9 +6853,9 @@ options(markdown.HTML.stylesheet = "css/style.css")
 ## References
 <ul>
 <li> Fox, J. (2005). Programmer&#39;s niche: How do you spell that number?.  <em>R News, 5</em>(1), 51-55.</li>
-<li> Heylighen, F. (1999). Advantages and limitations of formal expression.  <em>Foundations of Science, 5</em>, 25-56. <a href="http://dx.doi.org/10.1023/A:1009686703349">10.1023/A:1009686703349</a></li>
+<li> Heylighen, F. (1999). Advantages and limitations of formal expression.  <em>Foundations of Science, 5</em>, 25-56. <a href="https://doi.org/10.1023/A:1009686703349">10.1023/A:1009686703349</a></li>
 <li>Heylighen, F. &  Dewaele, J.-M. (1999). Formality of language: Definition, measurement and behavioral determinants.  <a href="http://pespmc1.vub.ac.be/Papers/Formality.pdf"><a href="http://pespmc1.vub.ac.be/Papers/Formality.pdf">http://pespmc1.vub.ac.be/Papers/Formality.pdf</a></a></li>
-<li>Heylighen, F. &  Dewaele, J.-M. (2002). Variation in the contextuality of language: An empirical measure.  <em>Foundations of Science, 7</em>(3),  293-340. <a href="http://dx.doi.org/10.1023/A:1019661126744">doi: 10.1023/A:1019661126744</a></li>
+<li>Heylighen, F. &  Dewaele, J.-M. (2002). Variation in the contextuality of language: An empirical measure.  <em>Foundations of Science, 7</em>(3),  293-340. <a href="https://doi.org/10.1023/A:1019661126744">doi: 10.1023/A:1019661126744</a></li>
 <li>Hu, M. & Liu, B. (2004). Mining Opinion features in customer reviews.  <a href="http://www.cs.uic.edu/~liub/publications/aaai04-featureExtract.pdf"><a href="http://www.cs.uic.edu/%7Eliub/publications/aaai04-featureExtract.pdf">http://www.cs.uic.edu/~liub/publications/aaai04-featureExtract.pdf</a></a></li>
 <li>Rinker,  T. (2013). qdap: Quantitative discourse analysis package.  <a href="http://github.com/trinker/qdap"><a href="http://github.com/trinker/qdap">http://github.com/trinker/qdap</a></a></li>
 <li>Rinker, T. (2013). reports: Package to asssist in report writing.  <a href="http://github.com/trinker/reports"><a href="http://github.com/trinker/reports">http://github.com/trinker/reports</a></a></li>

--- a/inst/Rmd_vignette/qdap_vignette.html
+++ b/inst/Rmd_vignette/qdap_vignette.html
@@ -10271,9 +10271,9 @@ qdap is designed to be a bridge between qualitative text and the quantitative to
 
 <ul>
 <li> Fox, J. (2005). Programmer&#39;s niche: How do you spell that number?.  <em>R News, 5</em>(1), 51-55.</li>
-<li> Heylighen, F. (1999). Advantages and limitations of formal expression.  <em>Foundations of Science, 5</em>, 25-56. <a href="http://dx.doi.org/10.1023/A:1009686703349">10.1023/A:1009686703349</a></li>
+<li> Heylighen, F. (1999). Advantages and limitations of formal expression.  <em>Foundations of Science, 5</em>, 25-56. <a href="https://doi.org/10.1023/A:1009686703349">10.1023/A:1009686703349</a></li>
 <li>Heylighen, F. &  Dewaele, J.-M. (1999). Formality of language: Definition, measurement and behavioral determinants.  <a href="http://pespmc1.vub.ac.be/Papers/Formality.pdf"><a href="http://pespmc1.vub.ac.be/Papers/Formality.pdf">http://pespmc1.vub.ac.be/Papers/Formality.pdf</a></a></li>
-<li>Heylighen, F. &  Dewaele, J.-M. (2002). Variation in the contextuality of language: An empirical measure.  <em>Foundations of Science, 7</em>(3),  293-340. <a href="http://dx.doi.org/10.1023/A:1019661126744">doi: 10.1023/A:1019661126744</a></li>
+<li>Heylighen, F. &  Dewaele, J.-M. (2002). Variation in the contextuality of language: An empirical measure.  <em>Foundations of Science, 7</em>(3),  293-340. <a href="https://doi.org/10.1023/A:1019661126744">doi: 10.1023/A:1019661126744</a></li>
 <li>Hu, M. & Liu, B. (2004). Mining Opinion features in customer reviews.  <a href="http://www.cs.uic.edu/~liub/publications/aaai04-featureExtract.pdf"><a href="http://www.cs.uic.edu/%7Eliub/publications/aaai04-featureExtract.pdf">http://www.cs.uic.edu/~liub/publications/aaai04-featureExtract.pdf</a></a></li>
 <li>Rinker,  T. (2013). qdap: Quantitative discourse analysis package.  <a href="http://github.com/trinker/qdap"><a href="http://github.com/trinker/qdap">http://github.com/trinker/qdap</a></a></li>
 <li>Rinker, T. (2013). reports: Package to asssist in report writing.  <a href="http://github.com/trinker/reports"><a href="http://github.com/trinker/reports">http://github.com/trinker/reports</a></a></li>

--- a/inst/qdap_Demonstration/PRESENTATION/MASTER.bib
+++ b/inst/qdap_Demonstration/PRESENTATION/MASTER.bib
@@ -185,7 +185,7 @@
   doi = {10.1111/j.1933-1592.2007.00114.x},
   issn = {1933-1592},
   publisher = {Blackwell Publishing Ltd},
-  url = {http://dx.doi.org/10.1111/j.1933-1592.2007.00114.x}
+  url = {https://doi.org/10.1111/j.1933-1592.2007.00114.x}
 }
 
 @ARTICLE{Clark2005,
@@ -1597,7 +1597,7 @@
   number = {1},
   doi = {10.1111/j.1741-4369.2011.00578.x},
   publisher = {Blackwell Publishing Ltd},
-  url = {http://dx.doi.org/10.1111/j.1741-4369.2011.00578.x}
+  url = {https://doi.org/10.1111/j.1741-4369.2011.00578.x}
 }
 
 @ARTICLE{Zyngier2008,


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) and Zenodo started using it for its badges as well. Accordingly, this PR updates all DOI links.

Cheers!